### PR TITLE
Remove GUI widget call from QgsTasks

### DIFF
--- a/zonal_exact/task_classes.py
+++ b/zonal_exact/task_classes.py
@@ -3,7 +3,7 @@ from exactextract import exact_extract
 import pandas as pd
 
 from qgis.core import QgsTask, QgsMessageLog, QgsVectorLayer
-from .user_communication import WidgetPlainTextWriter
+from PyQt5.QtCore import pyqtSignal
 
 
 class CalculateStatsTask(QgsTask):
@@ -11,11 +11,12 @@ class CalculateStatsTask(QgsTask):
     A class representing a task to calculate statistics using the exact_extract function.
     """
 
+    taskChanged = pyqtSignal(str)
+
     def __init__(
         self,
         description: str,
         flags: QgsTask.Flag,
-        widget_console: WidgetPlainTextWriter,
         result_list: List,
         polygon_layer: QgsVectorLayer,
         rasters: List[str],
@@ -27,7 +28,6 @@ class CalculateStatsTask(QgsTask):
         Attributes:
         description (str): The description of the task.
         flags (QgsTask.Flag): The flags for the task.
-        widget_console (WidgetPlainTextWriter): The console to write task progress.
         result_list (List[str]): The list to store the results of the task.
         polygon_layer (QgsVectorLayer): The polygon layer to perform the statistics on.
         rasters (List[str]): The list of raster files to use in the statistics.
@@ -37,7 +37,6 @@ class CalculateStatsTask(QgsTask):
         """
         super().__init__(description, flags)
         self.description = description
-        self.widget_console: WidgetPlainTextWriter = widget_console
         self.polygon_layer: QgsVectorLayer = polygon_layer
         self.rasters: List[str] = rasters
         self.weights: List[str] = weights
@@ -52,12 +51,9 @@ class CalculateStatsTask(QgsTask):
         """
         Run the task and calculate the statistics using exactextract
         """
-        QgsMessageLog.logMessage(
-            f"Started task: {self.description} with {self.polygon_layer.featureCount()} polygons"
-        )
-        self.widget_console.write_info(
-            f"Started task: {self.description} with {self.polygon_layer.featureCount()} polygons"
-        )
+        message = f"Started task: {self.description} with {self.polygon_layer.featureCount()} polygons"
+        QgsMessageLog.logMessage(message)
+        self.taskChanged.emit(message)
 
         result_stats = exact_extract(
             vec=self.polygon_layer,
@@ -79,9 +75,8 @@ class CalculateStatsTask(QgsTask):
         Args:
             result (bool):  The result of the task. True if  the task was successful otherwise False.
         """
-        self.widget_console.write_info(
-            f"Finished task: {self.description}, result: {'Successful' if result else 'Failed'}"
-        )
+        message = f"Finished task: {self.description}, result: {'Successful' if result else 'Failed'}"
+        self.taskChanged.emit(message)
 
 
 class MergeStatsTask(QgsTask):
@@ -89,11 +84,12 @@ class MergeStatsTask(QgsTask):
     A custom QgsTask for merging statistics from a list of pandas DataFrames and optionally prefixing column names.
     """
 
+    taskChanged = pyqtSignal(str)
+
     def __init__(
         self,
         description: str,
         flags: QgsTask.Flag,
-        widget_console: WidgetPlainTextWriter,
         result_list: List,
         index_column: str,
         prefix: str,
@@ -102,14 +98,12 @@ class MergeStatsTask(QgsTask):
         Attributes:
             description (str): A description of the task.
             flags (QgsTask.Flag): Flags indicating the task's behavior.
-            widget_console (WidgetPlainTextWriter): A widget for writing console output.
             result_list (List[pd.DataFrame]): A list of pandas DataFrames containing the statistics to be merged.
             index_column (str): The name of the index column.
             prefix (str): A prefix string to be added to the column names.
         """
         super().__init__(description, flags)
         self.description: str = description
-        self.widget_console: WidgetPlainTextWriter = widget_console
         self.result_list: List[pd.DataFrame] = result_list
         self.index_column: str = index_column
         self.prefix: str = prefix
@@ -121,10 +115,9 @@ class MergeStatsTask(QgsTask):
         """
         Merges all dataframes in the list into one dataframe and adds prefix to column names if necessary.
         """
-        QgsMessageLog.logMessage(f"Inside MergeStatsTask Task: {self.description}")
-        self.widget_console.write_info(
-            f"Inside MergeStatsTask Task: {self.description}"
-        )
+        message = f"Inside MergeStatsTask Task: {self.description}"
+        QgsMessageLog.logMessage(message)
+        self.taskChanged.emit(message)
 
         calculated_stats = pd.concat(self.result_list)
 
@@ -148,6 +141,5 @@ class MergeStatsTask(QgsTask):
         Args:
             result (bool):  The result of the task. True if  the task was successful otherwise False.
         """
-        self.widget_console.write_info(
-            f"Finished MergeStatsTask Task: {self.description}, result: {'Successful' if result else 'Failed'}"
-        )
+        message = f"Finished MergeStatsTask Task: {self.description}, result: {'Successful' if result else 'Failed'}"
+        self.taskChanged.emit(message)

--- a/zonal_exact/tests/test_calculate_stats_task.py
+++ b/zonal_exact/tests/test_calculate_stats_task.py
@@ -21,7 +21,6 @@ def init_calculate_stats_task(setup_layers):
     task = CalculateStatsTask(
         "Test Task",
         QgsTask.CanCancel,
-        console,
         [],
         vector_layer,
         [raster_layer_path],
@@ -29,18 +28,19 @@ def init_calculate_stats_task(setup_layers):
         stats_to_calculate,
         ["id"],
     )
+    task.taskChanged.connect(console.write_info)
 
-    return task
+    return task, console
 
 
 def test_task_init(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
 
     assert task.description == "Test Task"
 
 
 def test_task_run(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     result = task.run()
 
     # Check if the task ran successfully and variables are set correctly
@@ -49,21 +49,21 @@ def test_task_run(init_calculate_stats_task):
 
 
 def test_task_console_output(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, console = init_calculate_stats_task
     task.run()
     # Simulate task finished with success and failure
     task.finished(True)
     task.finished(False)
 
     # Check if the console output is correct
-    console_output = task.widget_console.plain_text_widget.toPlainText().split("\n")
+    console_output = console.plain_text_widget.toPlainText().split("\n")
     assert console_output[0] == "[INFO]: Started task: Test Task with 12 polygons"
     assert console_output[1] == "[INFO]: Finished task: Test Task, result: Successful"
     assert console_output[2] == "[INFO]: Finished task: Test Task, result: Failed"
 
 
 def test_task_calculation(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     task.run()
 
     # Check for correctness of the output statistics
@@ -76,7 +76,7 @@ def test_task_calculation(init_calculate_stats_task):
 
 
 def test_task_single_nodata_pixel_polygon(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     task.run()
 
     result_df = task.result_list[0]
@@ -91,7 +91,7 @@ def test_task_single_nodata_pixel_polygon(init_calculate_stats_task):
 
 
 def test_task_single_pixel_polygon(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     task.run()
 
     result_df = task.result_list[0]
@@ -112,7 +112,7 @@ def test_task_single_pixel_polygon(init_calculate_stats_task):
 
 
 def test_task_single_big_polygon(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     task.run()
 
     result_df = task.result_list[0]
@@ -127,7 +127,7 @@ def test_task_single_big_polygon(init_calculate_stats_task):
 
 
 def test_task_single_polygon_outside_raster(init_calculate_stats_task):
-    task = init_calculate_stats_task
+    task, _ = init_calculate_stats_task
     task.run()
 
     result_df = task.result_list[0]

--- a/zonal_exact/tests/test_merge_stats_task.py
+++ b/zonal_exact/tests/test_merge_stats_task.py
@@ -47,23 +47,23 @@ def init_merge_stats_task(setup_stats_dfs):
     task = MergeStatsTask(
         "Merge statistics",
         QgsTask.CanCancel,
-        console,
         result_list,
         "id",
         "pytest_",
     )
+    task.taskChanged.connect(console.write_info)
 
-    return task
+    return task, console
 
 
 def test_task_init(init_merge_stats_task):
-    task = init_merge_stats_task
+    task, _ = init_merge_stats_task
 
     assert task.description == "Merge statistics"
 
 
 def test_task_run(init_merge_stats_task):
-    task = init_merge_stats_task
+    task, _ = init_merge_stats_task
     result = task.run()
 
     # Check if the task ran successfully and variables are set correctly
@@ -89,14 +89,14 @@ def test_task_run(init_merge_stats_task):
 
 
 def test_task_console_output(init_merge_stats_task):
-    task = init_merge_stats_task
+    task, console = init_merge_stats_task
     task.run()
     # Simulate task finished with success and failure
     task.finished(True)
     task.finished(False)
 
     # Check if the console output is correct
-    console_output = task.widget_console.plain_text_widget.toPlainText().split("\n")
+    console_output = console.plain_text_widget.toPlainText().split("\n")
     assert console_output[0] == "[INFO]: Inside MergeStatsTask Task: Merge statistics"
     assert (
         console_output[1]


### PR DESCRIPTION
As per requirement stated in [QgsTask](https://docs.qgis.org/3.34/en/docs/pyqgis_developer_cookbook/tasks.html) warning there should be no calls to GUI widgets. This pull removes call to widget console and changes it to `pyqtSignal` call.